### PR TITLE
replace google ads package & update Version

### DIFF
--- a/kWordle.xcodeproj/project.pbxproj
+++ b/kWordle.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		737D4CE228093C3600CD8CBD /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737D4CE128093C3600CD8CBD /* MainView.swift */; };
 		737D4CE428093C6200CD8CBD /* AnswerBoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737D4CE328093C6200CD8CBD /* AnswerBoardView.swift */; };
 		737D4CE82809539D00CD8CBD /* WordDictManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737D4CE72809539D00CD8CBD /* WordDictManager.swift */; };
-		7384B9FB28168DDC00D14652 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 7384B9FA28168DDC00D14652 /* GoogleMobileAds */; };
 		7384B9FD28168E7300D14652 /* GoogleAds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7384B9FC28168E7300D14652 /* GoogleAds.swift */; };
 		738C80D1280D473200D8FCA5 /* 5Jamo.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 738C80D0280D473200D8FCA5 /* 5Jamo.tsv */; };
 		738C80D7280D61D600D8FCA5 /* WordDict.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738C80D6280D61D600D8FCA5 /* WordDict.swift */; };
@@ -41,6 +40,7 @@
 		73FD63B127EDCF920041036F /* kWordleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FD63B027EDCF920041036F /* kWordleApp.swift */; };
 		73FD63B527EDCF940041036F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73FD63B427EDCF940041036F /* Assets.xcassets */; };
 		73FD63B827EDCF940041036F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73FD63B727EDCF940041036F /* Preview Assets.xcassets */; };
+		983949312B3C4C5200C87348 /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 983949302B3C4C5200C87348 /* GoogleMobileAds */; };
 		CC1BB899281AE13800BAA6FA /* HapticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1BB898281AE13800BAA6FA /* HapticsManager.swift */; };
 		CC29723229AB4C46006D2E44 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = CC29723129AB4C46006D2E44 /* Lottie */; };
 		CC29723929AB510B006D2E44 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC29723829AB510B006D2E44 /* LottieView.swift */; };
@@ -162,9 +162,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				983949312B3C4C5200C87348 /* GoogleMobileAds in Frameworks */,
 				CC7D1D4A28169AAB00CD7BFD /* RealmSwift in Frameworks */,
 				CC7D1D4828169AAB00CD7BFD /* Realm in Frameworks */,
-				7384B9FB28168DDC00D14652 /* GoogleMobileAds in Frameworks */,
 				733A74CB281290F900B49310 /* FirebaseAnalytics in Frameworks */,
 				733A74CD281290F900B49310 /* FirebaseFirestore in Frameworks */,
 				CC29723229AB4C46006D2E44 /* Lottie in Frameworks */,
@@ -416,8 +416,8 @@
 				733A74CC281290F900B49310 /* FirebaseFirestore */,
 				CC7D1D4728169AAB00CD7BFD /* Realm */,
 				CC7D1D4928169AAB00CD7BFD /* RealmSwift */,
-				7384B9FA28168DDC00D14652 /* GoogleMobileAds */,
 				CC29723129AB4C46006D2E44 /* Lottie */,
+				983949302B3C4C5200C87348 /* GoogleMobileAds */,
 			);
 			productName = kWordle;
 			productReference = 73FD63AD27EDCF920041036F /* Handeul.app */;
@@ -431,7 +431,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1310;
-				LastUpgradeCheck = 1310;
+				LastUpgradeCheck = 1510;
 				TargetAttributes = {
 					73FD63AC27EDCF920041036F = {
 						CreatedOnToolsVersion = 13.1;
@@ -451,9 +451,9 @@
 			packageReferences = (
 				733A74C9281290F900B49310 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				CC7D1D4628169AAB00CD7BFD /* XCRemoteSwiftPackageReference "realm-swift" */,
-				7384B9F928168DDC00D14652 /* XCRemoteSwiftPackageReference "GoogleMobileAds" */,
 				CC29723029AB4C46006D2E44 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				CC29723529AB4F98006D2E44 /* XCRemoteSwiftPackageReference "Lottie-SwiftUI" */,
+				9839492F2B3C4C5200C87348 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 			);
 			productRefGroup = 73FD63AE27EDCF920041036F /* Products */;
 			projectDirPath = "";
@@ -623,6 +623,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -685,6 +686,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -709,7 +711,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20230317;
+				CURRENT_PROJECT_VERSION = 20231227;
 				DEVELOPMENT_ASSET_PATHS = "\"kWordle/Preview Content\"";
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				ENABLE_PREVIEWS = YES;
@@ -728,7 +730,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.game.handeul;
 				PRODUCT_NAME = Handeul;
@@ -744,7 +746,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 20230317;
+				CURRENT_PROJECT_VERSION = 20231227;
 				DEVELOPMENT_ASSET_PATHS = "\"kWordle/Preview Content\"";
 				DEVELOPMENT_TEAM = 9TH57H8UP9;
 				ENABLE_PREVIEWS = YES;
@@ -763,7 +765,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.7;
+				MARKETING_VERSION = 1.7.1;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.game.handeul;
 				PRODUCT_NAME = Handeul;
@@ -802,15 +804,15 @@
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 8.0.0;
+				minimumVersion = 10.0.0;
 			};
 		};
-		7384B9F928168DDC00D14652 /* XCRemoteSwiftPackageReference "GoogleMobileAds" */ = {
+		9839492F2B3C4C5200C87348 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/quanghits/GoogleMobileAds.git";
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.0;
+				minimumVersion = 10.14.0;
 			};
 		};
 		CC29723029AB4C46006D2E44 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
@@ -850,9 +852,9 @@
 			package = 733A74C9281290F900B49310 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFirestore;
 		};
-		7384B9FA28168DDC00D14652 /* GoogleMobileAds */ = {
+		983949302B3C4C5200C87348 /* GoogleMobileAds */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 7384B9F928168DDC00D14652 /* XCRemoteSwiftPackageReference "GoogleMobileAds" */;
+			package = 9839492F2B3C4C5200C87348 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
 			productName = GoogleMobileAds;
 		};
 		CC29723129AB4C46006D2E44 /* Lottie */ = {

--- a/kWordle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/kWordle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
-        "version" : "0.20220203.2"
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
       }
     },
     {
-      "identity" : "boringssl-swiftpm",
+      "identity" : "app-check",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
-        "version" : "0.9.1"
+        "revision" : "5746b2d35c91c50581590ed97abe4c06b5037274",
+        "version" : "10.18.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "111d8d6ad1a1afd6c8e9561d26e55ab1e74fcb42",
-        "version" : "8.15.0"
+        "revision" : "c60c958e707c50a9cf8bcb7cfd7d51c566d726c5",
+        "version" : "10.19.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ef819db8c58657a6ca367322e73f3b6322afe0a2",
-        "version" : "8.15.0"
+        "revision" : "6b332152355c372ace9966d8ee76ed191f97025e",
+        "version" : "10.17.0"
       }
     },
     {
@@ -41,26 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
-        "version" : "9.2.1"
-      }
-    },
-    {
-      "identity" : "googlemobileads",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/quanghits/GoogleMobileAds.git",
-      "state" : {
-        "revision" : "271e6d6bc1d7756a88fe82df558145a264a34331",
-        "version" : "9.8.0"
-      }
-    },
-    {
-      "identity" : "googleusermessagingplatform",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/quanghits/GoogleUserMessagingPlatform.git",
-      "state" : {
-        "revision" : "f322d91b6b0497b727b228a5fa5b9394e7886d3a",
-        "version" : "2.0.0"
+        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
+        "version" : "9.3.0"
       }
     },
     {
@@ -68,17 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
-        "version" : "7.11.0"
+        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
+        "version" : "7.12.1"
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
-        "version" : "1.44.3-grpc"
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
       }
     },
     {
@@ -86,8 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
-        "version" : "1.7.2"
+        "revision" : "115f75e43851774934d695449a4836123c3246e1",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {
@@ -122,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
-        "version" : "2.30908.0"
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
       }
     },
     {
@@ -131,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
-        "version" : "2.2.0"
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -151,6 +142,24 @@
       "state" : {
         "branch" : "master",
         "revision" : "8524c4e25b506a0d54505efb9cdb40a328ab0792"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
+      "state" : {
+        "revision" : "70516c9e799a366ff90c1a70c09c48f7c076fd8a",
+        "version" : "10.14.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "129fa838520cd02174f890ae0cfe0242e60714ae",
+        "version" : "2.1.0"
       }
     },
     {

--- a/kWordle.xcodeproj/xcshareddata/xcschemes/kWordle.xcscheme
+++ b/kWordle.xcodeproj/xcshareddata/xcschemes/kWordle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1310"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- 기존 [GoogleMobileAds](https://github.com/quanghits/GoogleMobileAds)에서 공식버전인 [swift-package-manager-google-mobile-ads](https://github.com/googleads/swift-package-manager-google-mobile-ads) 로 업데이트